### PR TITLE
revert to old px4 firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,18 @@ clean:
 nuke:
 	cd; rm -r /software/bin; rm -r /software/lib; rm -r /software/build
 
+# Temporary command to build gazebo and px4 firmware until this is in setup_sim.sh
+# Only call this from within the docker container - make sure you have the new image
+setup-sim:
+	pwd
+	cd /PX4Firmware
+	num_procs_avail=$(($(grep -c ^processor /proc/cpuinfo)-1))
+	make posix_sitl_default gazebo -j$((num_procs_avail > 1 ? num_procs_avail : 1))
+
+
 .PHONY: build
 .PHONY: bash
 .PHONY: run-all
 .PHONY: clean
 .PHONY: nuke
+.PHONY: setup-sim

--- a/Makefile
+++ b/Makefile
@@ -13,18 +13,8 @@ clean:
 nuke:
 	cd; rm -r /software/bin; rm -r /software/lib; rm -r /software/build
 
-# Temporary command to build gazebo and px4 firmware until this is in setup_sim.sh
-# Only call this from within the docker container - make sure you have the new image
-setup-sim:
-	pwd
-	cd /PX4Firmware
-	num_procs_avail=$(($(grep -c ^processor /proc/cpuinfo)-1))
-	make posix_sitl_default gazebo -j$((num_procs_avail > 1 ? num_procs_avail : 1))
-
-
 .PHONY: build
 .PHONY: bash
 .PHONY: run-all
 .PHONY: clean
 .PHONY: nuke
-.PHONY: setup-sim

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,14 @@ services:
       - ${PWD}/Makefile:/Makefile
     container_name: maav-run
     command: "make ${ACTION}"
+  gazebo:
+    image: maav-software
+    volumes:
+      - ./software:/software
+      - ${PWD}/Makefile:/Makefile
+      - $HOME/.Xauthority:/root/.Xauthority:rw
+    environment:
+      - DISPLAY
+    network_mode: "host"
+    container_name: gazebo-run
+    command: "gazebo"

--- a/scripts/build_gazebo.sh
+++ b/scripts/build_gazebo.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Run this command from the container only to build the PX4 firmware.
+# This will launch a PX4 shell, so once the command stops running you can
+# CTRL+C or exit. To save the build files, docker commit your container
+cd /PX4Firmware
+num_procs_avail=$(($(grep -c ^processor /proc/cpuinfo)-1))
+make posix_sitl_default gazebo -j$((num_procs_avail > 1 ? num_procs_avail : 1))

--- a/scripts/setup_sim.sh
+++ b/scripts/setup_sim.sh
@@ -7,10 +7,7 @@ curl -sSL http://get.gazebosim.org | sh
 
 # Install PX4 firmware
 echo "Installing PX4 firmware"
-wget https://github.com/PX4/Firmware/archive/v1.9.2.zip -O Firmware.zip
-unzip Firmware.zip
-rm Firmware.zip
-mv Firmware-1.9.2 PX4Firmware
+git clone --single-branch --branch v1.8.2 https://github.com/PX4/Firmware/ PX4Firmware
 
 # Ubuntu Config
 echo "We must first remove modemmanager"


### PR DESCRIPTION
px4 firmware does not build unless pulled from git, so switch to pulling from 1.8.2 tag (newer versions deprecate posix build target)

the `make posix_sitl_default gazebo` target actually launches the px4 shell and gazebo, so this is not added to setup_sim.sh until we can figure out px4's makefile and disable this feature. as a workaround, i added a temporary makefile targe to build the sim on the docker (once you have the new px4 firmware)